### PR TITLE
Removed colon from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@ ExampleOpenSourceProject
 
 MakeSchool Open Source Project
 
-#Note:
+#Note
 
 Please use the develop branch to suggest changes to this project!


### PR DESCRIPTION
The colon is unnecessary if the header is already bold and larger text
(-Garry Tan)
